### PR TITLE
Add QR parsing for XT Wallet deep links + generic Signum address detection

### DIFF
--- a/app/dashboard/_layout.tsx
+++ b/app/dashboard/_layout.tsx
@@ -37,7 +37,7 @@ export default function Layout() {
       initialRouteName="overview"
       screenOptions={{
         headerShown: false,
-        tabBarStyle: { height: 85, paddingTop: 15, paddingBottom: 15 },
+        tabBarStyle: { height: 116, paddingTop: 15, paddingBottom: 56 },
       }}
     >
       <Tabs.Screen

--- a/src/components/CameraDialog.tsx
+++ b/src/components/CameraDialog.tsx
@@ -12,6 +12,7 @@ import { Text } from "./Text";
 import { Button } from "./Button";
 import { Dialog } from "./Dialog";
 import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
+import { findSignumAddress } from "@/utils/findSignumAddress";
 
 interface Props {
   onCodeScanned: (code: BarcodeScanningResult) => void;
@@ -32,8 +33,17 @@ export const CameraDialog = ({ onCodeScanned }: Props) => {
   };
 
   const scanEvent = (code: BarcodeScanningResult) => {
-    onCodeScanned(code);
-    hideDialog();
+    const scannedData = code.data?.trim();
+    if (!scannedData) return;
+
+    const address = findSignumAddress(scannedData);
+
+    if (address) {
+      onCodeScanned({ ...code, data: address });
+      hideDialog();
+    } else {
+      alert(t("invalidSignumQRCode"));
+    }
   };
 
   const canUseCamera =

--- a/src/utils/findSignumAddress.ts
+++ b/src/utils/findSignumAddress.ts
@@ -1,0 +1,64 @@
+// utils/findSignumAddress.ts
+const RS_RE =
+  /\bS-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{5}\b/i;
+
+// Helper to decode Base64 or Base64URL into a UTF-8 string
+function decodeBase64Url(b64: string): string {
+  // Replace URL-safe chars and restore padding
+  const base64 = b64.replace(/-/g, "+").replace(/_/g, "/")
+                   + "===".slice((b64.length + 3) % 4);
+
+  if (typeof atob === "function") {
+    // Browser / React Native: atob returns binary string
+    const bin = atob(base64);
+    // Convert binary string to UTF-8
+    let out = "";
+    for (let i = 0; i < bin.length; i++) {
+      out += "%" + bin.charCodeAt(i).toString(16).padStart(2, "0");
+    }
+    return decodeURIComponent(out);
+  }
+  return Buffer.from(base64, "base64").toString("utf-8");
+}
+
+export function findSignumAddress(input: string): string | null {
+  const str = decodeURIComponent(input.trim());
+
+  // 1) Try parsing as signum:// deeplink
+  try {
+    // Normalize the URL so `new URL()` can parse it
+    const normalized = str.replace(/^web\+/, "").replace(/^signum:/i, "signum://");
+    const u = new URL(normalized);
+
+    // v1 deeplink: address is inside Base64/JSON payload
+    const payload = u.searchParams.get("payload");
+    if (payload) {
+      try {
+        const obj = JSON.parse(decodeBase64Url(payload));
+        const cand: string | undefined = obj?.recipient;
+        if (cand && RS_RE.test(cand)) return cand.toUpperCase();
+      } catch {
+        // Ignore JSON/base64 decoding errors
+      }
+    }
+
+    // Legacy deeplink: ?recipient=... or last path segment
+    const candidate = u.searchParams.get("recipient") || u.pathname.split("/").pop() || "";
+    if (RS_RE.test(candidate)) return candidate.toUpperCase();
+  } catch {
+    // Not a valid URL format — will try other methods
+  }
+
+  // 2) Fallback: input might be raw Base64/JSON without a URL
+  try {
+    const obj = JSON.parse(decodeBase64Url(str));
+    const cand: string | undefined = obj?.recipient;
+    if (cand && RS_RE.test(cand)) return cand.toUpperCase();
+  } catch {
+    // Ignore if not Base64/JSON
+  }
+
+  // 3) Final fallback: match raw text for an S-... address
+  const m = str.match(RS_RE);
+  return m ? m[0].toUpperCase() : null;
+}


### PR DESCRIPTION
Adds support to find and decode a Signum address from QR codes generated by the XT Wallet. These QRs contain a deeplink with a Base64-encoded payload. The scanner now also searches the scanned text for Signum address and uses the first valid hit.

---

Fixed the overlap of Android navigation bar (3-buttons) with mobile wallet bottom menu bar.

before: 
<img width="368" height="176" alt="image" src="https://github.com/user-attachments/assets/b6b5e13f-5626-4453-9b5b-25077edfe3a6" />

now: 
<img width="368" height="196" alt="image" src="https://github.com/user-attachments/assets/0b09602f-7948-4cba-ae0e-2fbac13fa26b" />

