### PR TITLE
Add clear button, crypto adapter, reserved balance, recipient account name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@signumjs/core": "^2.0.6",
         "@signumjs/crypto": "^2.0.6",
         "@signumjs/http": "^2.0.8",
-        "@signumjs/react-native-expo-crypto-adapter": "github:ANGiS-X/signumjs-react-native-crypto-adapter#main",
+        "@signumjs/react-native-expo-crypto-adapter": "^1.0.4",
         "@signumjs/standards": "^2.0.7",
         "@signumjs/util": "^2.0.6",
         "@tanstack/react-query": "^5.80.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@signumjs/core": "^2.0.6",
     "@signumjs/crypto": "^2.0.6",
     "@signumjs/http": "^2.0.8",
-    "@signumjs/react-native-expo-crypto-adapter": "github:ANGiS-X/signumjs-react-native-crypto-adapter#main",
+    "@signumjs/react-native-expo-crypto-adapter": "^1.0.4",
     "@signumjs/standards": "^2.0.7",
     "@signumjs/util": "^2.0.6",
     "@tanstack/react-query": "^5.80.7",

--- a/src/components/Account/Switcher.tsx
+++ b/src/components/Account/Switcher.tsx
@@ -60,7 +60,7 @@ export const AccountSwitcher = ({ href }: Props) => {
 
           <View className="border rounded-lg border-card-border dark:border-card-border-dark p-4 opacity-80">
             <FontAwesome6
-              name="arrows-rotate"
+              name="right-left"
               size={20}
               color={iconColor.default}
             />

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,8 +1,12 @@
-import { forwardRef } from "react";
+import React, { forwardRef, useMemo, useRef, useState } from "react";
 import {
   TextInput as NativeTextInput,
   type TextInputProps,
-  Platform
+  Platform,
+  View,
+  Pressable,
+  Text,
+  type TextStyle,
 } from "react-native";
 import clsx from "clsx";
 import { useColorScheme } from "react-native";
@@ -11,6 +15,8 @@ interface Props extends Omit<TextInputProps, "className" | "style"> {
   extraClassNames?: string;
   size?: "small" | "medium" | "large" | "extraLarge";
   style?: TextInputProps["style"];
+  clearButtonEnabled?: boolean;
+  onClear?: () => void;
 }
 
 type SizeDef = { fontSize: number; lineHeight: number; padV: number };
@@ -26,6 +32,15 @@ export const TextInput = forwardRef<NativeTextInput, Props>((props, ref) => {
   const s = sizeMap[props.size ?? "medium"];
   const iosBump = Platform.OS === "ios" ? 1 : 0;
   const isMultiline = !!props.multiline;
+  const clearButtonEnabled = props.clearButtonEnabled ?? true;
+
+  const [innerValue, setInnerValue] = useState<string>(
+    typeof props.value === "string" ? props.value : ""
+  );
+
+  const inputRef = useRef<NativeTextInput>(null);
+
+  React.useImperativeHandle(ref, () => inputRef.current as NativeTextInput);
 
   const classNames = clsx([
     "rounded-lg border border-card-border dark:border-card-border-dark w-full bg-muted dark:bg-muted-dark",
@@ -34,30 +49,97 @@ export const TextInput = forwardRef<NativeTextInput, Props>((props, ref) => {
     props.extraClassNames,
   ]);
 
-  const baseStyle = {
-    fontSize: s.fontSize,
-    paddingVertical: s.padV + iosBump,
-    paddingHorizontal: 16,
-    flexShrink: 1,
-    minWidth: 0,
-    maxWidth: "100%",
-    ...(isMultiline
-      ? { lineHeight: s.lineHeight + iosBump, textAlignVertical: "top" as any }
-      : {}),
-  } as const;
+  const baseStyle = useMemo(() => {
+    const style: TextStyle = {
+      fontSize: s.fontSize,
+      paddingVertical: s.padV + iosBump,
+      paddingHorizontal: 16,
+      flexShrink: 1,
+      minWidth: 0,
+      maxWidth: "100%",
+      // Make room for the clear button
+      paddingRight: 16,
+      ...(isMultiline
+        ? { lineHeight: s.lineHeight + iosBump, textAlignVertical: "top" as any }
+        : {}),
+    };
+    return style;
+  }, [s.fontSize, s.padV, iosBump, isMultiline]);
 
-  const { style: userStyle, ...rest } = props;
+  const { style: userStyle, onChangeText, value, editable = true, ...rest } = props;
+
+  const currentText = typeof value === "string" ? value : innerValue;
+  const showClear =
+    clearButtonEnabled && editable && !props.secureTextEntry && currentText.length > 0;
+
+  const handleChangeText = (txt: string) => {
+    if (typeof value !== "string") {
+      setInnerValue(txt);
+    }
+    onChangeText?.(txt);
+  };
+
+  const handleClear = () => {
+    // Clear native input visually
+    if (Platform.OS === "android") {
+      // Android doesn't expose a native clear button; clear via state and ref
+      inputRef.current?.clear?.();
+    }
+    // Update state/prop callback
+    if (typeof value !== "string") setInnerValue("");
+    onChangeText?.("");
+    props.onClear?.();
+  };
+
+  const iconFg = scheme === "dark" ? "#D4D4D8" : "#52525B";
+  const iconBg = scheme === "dark" ? "#27272A" : "#E4E4E7";
 
   return (
-    <NativeTextInput
-      ref={ref}
-      className={classNames}
-      // Styles MERGEN: first Defaults, then userStyle
-      style={[baseStyle, userStyle]}
-      placeholderTextColor={scheme === "dark" ? "#A1A1AA" : "#71717A"}
-      underlineColorAndroid="transparent"
-      allowFontScaling={false}
-      {...rest}
-    />
+    <View className="relative w-full">
+      <NativeTextInput
+        ref={inputRef}
+        className={classNames}
+        style={[baseStyle, userStyle]}
+        placeholderTextColor={scheme === "dark" ? "#A1A1AA" : "#71717A"}
+        underlineColorAndroid="transparent"
+        allowFontScaling={false}
+        // Avoid the native iOS clear button so we don't end up with two buttons
+        {...(Platform.OS === "ios" ? { clearButtonMode: "never" as const } : {})}
+        value={value}
+        onChangeText={handleChangeText}
+        editable={editable}
+        {...rest}
+      />
+
+      {showClear && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Eingabe löschen"
+          onPress={handleClear}
+          hitSlop={8}
+          style={{
+            position: "absolute",
+            right: 10,
+            top: "50%",
+            transform: [{ translateY: -12 }],
+          }}
+        >
+          <View
+            style={{
+              width: 24,
+              height: 24,
+              borderRadius: 12,
+              backgroundColor: iconBg,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Text style={{ fontSize: 16, lineHeight: 16, color: iconFg }}>×</Text>
+          </View>
+        </Pressable>
+      )}
+    </View>
   );
 });
+
+export default TextInput;

--- a/src/features/AccountWizard/Import/sections/SeedPhraseField/index.tsx
+++ b/src/features/AccountWizard/Import/sections/SeedPhraseField/index.tsx
@@ -30,7 +30,7 @@ export const SeedPhraseField = () => {
           render={({ field: { onChange, onBlur, value } }) => (
             <TextInput
               onBlur={onBlur}
-              onChangeText={onChange}
+              onChangeText={(text) => onChange(text.toLowerCase())} 
               value={value}
               extraClassNames="font-medium w-full min-h-40"
               size="large"

--- a/src/features/Dashboard/Transfer/components/ResolvedAccountCard.tsx
+++ b/src/features/Dashboard/Transfer/components/ResolvedAccountCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
@@ -7,6 +7,7 @@ import { Card } from "@/components/Card";
 import { asAddress } from "@/utils/account/asAddress";
 import type { TransactionCreation } from "../utils/types";
 import { useAccount } from "@/hooks/useAccount";
+import { useLedgerService } from "@/hooks/useLedgerService";
 
 interface Props {
   simple?: boolean;
@@ -16,21 +17,64 @@ export const ResolvedAccountCard = ({ simple }: Props) => {
   const { t } = useTranslation();
   const { watch } = useFormContext<TransactionCreation>();
   const { accountId } = useAccount();
+  const { ledgerService } = useLedgerService();
 
   const recipient = watch("recipient");
 
   const resolvedAccount = useMemo(() => {
-    if (!recipient.trim()) return;
-
+    if (!recipient?.trim()) return;
     try {
-      let accountId = recipient;
-      return asAddress(accountId);
-    } catch (error) {
+      return asAddress(recipient);
+    } catch {
       return;
     }
   }, [recipient]);
 
-  if (recipient === "0" || recipient.includes("2222-2222-2222-2222")) {
+  const [accountName, setAccountName] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const rsAddress = useMemo(
+    () => (resolvedAccount ? resolvedAccount.getReedSolomonAddress() : ""),
+    [resolvedAccount]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchName = async () => {
+      setAccountName("");
+
+      if (!rsAddress || !ledgerService) return;
+
+      try {
+        setLoading(true);
+        const acc = await ledgerService.ledgerInstance.account.getAccount({
+          accountId: rsAddress,
+        });
+        if (cancelled) return;
+
+        const rawName = (acc?.name ?? "").trim();
+        if (rawName) {
+          const shortName =
+            rawName.length > 30 ? `${rawName.slice(0, 30)}…` : rawName;
+          setAccountName(shortName);
+        } else {
+          setAccountName("");
+        }
+      } catch {
+        if (!cancelled) setAccountName("");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void fetchName();
+    return () => {
+      cancelled = true;
+    };
+  }, [rsAddress, ledgerService]);
+
+  if (recipient === "0" || recipient?.includes("2222-2222-2222-2222")) {
     return (
       <Card>
         <View className="gap-1 w-full">
@@ -65,6 +109,12 @@ export const ResolvedAccountCard = ({ simple }: Props) => {
               {resolvedAccount.getReedSolomonAddress()}
             </Text>
 
+            {!loading && !!accountName && (
+              <Text fullWidth color="primary" size="small">
+                {accountName}
+              </Text>
+            )}
+
             <Text fullWidth color="muted" size="small">
               {resolvedAccount.getNumericId()}
             </Text>
@@ -76,6 +126,13 @@ export const ResolvedAccountCard = ({ simple }: Props) => {
                 address: resolvedAccount.getReedSolomonAddress(),
               })}
             </Text>
+
+            {!loading && !!accountName && (
+              <Text fullWidth color="primary">
+                {accountName}
+              </Text>
+            )}
+
             <Text fullWidth color="muted" size="small">
               {t("transfer.resolvedRecipientAddressHint")} 😁
             </Text>

--- a/src/features/Dashboard/Transfer/sections/HoldingsSelection/components/AmountBox/index.tsx
+++ b/src/features/Dashboard/Transfer/sections/HoldingsSelection/components/AmountBox/index.tsx
@@ -91,7 +91,7 @@ export const AmountBox = () => {
           />
 
           {!!(!notEnoughFunds && signaAmountMarketValue) && (
-            <Text size="large" color="muted" className="font-medium">
+            <Text size="large" color="muted" className="font-medium text-center">
               {`${symbol}${formatNumber({
                 value: signaAmountMarketValue,
                 isFiat: true,
@@ -100,12 +100,12 @@ export const AmountBox = () => {
           )}
 
           {(notEnoughFunds && !insufficientFeeFunds) && (
-            <Text color="error" className="font-medium">
+            <Text color="error" className="font-medium text-center">
               {t("notEnoguhFunds")}
             </Text>
           )}
           {(!notEnoughFunds && insufficientFeeFunds) && (
-            <Text color="error" className="font-medium">
+            <Text color="error" className="font-medium text-center">
                {t("notEnoughForFee")}
             </Text>
           )}

--- a/src/features/Dashboard/Transfer/sections/HoldingsSelection/index.tsx
+++ b/src/features/Dashboard/Transfer/sections/HoldingsSelection/index.tsx
@@ -15,6 +15,8 @@ import { AssetPickerDialog } from "./components/AssetPickerDialog";
 import { AmountBox } from "./components/AmountBox";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { useTokenTransactionalData } from "@/hooks/useTokenTransactionalData";
+import { PUBLIC_RESERVED_SIGNA_FOR_TX_FEE } from "@/types/constants";
+import { SignaSymbol } from "@/components/SignaSymbol";
 
 export const HoldingsSelection = () => {
   const { t } = useTranslation();
@@ -88,24 +90,33 @@ export const HoldingsSelection = () => {
                 asset={asset}
                 isAssetSigna={isAssetSigna}
                 readableTicker={readableTicker}
-                readableAvailableBalance={readableAvailableBalance}
+                readableAvailableBalance={Math.max(
+                  0,
+                  readableAvailableBalance -
+                    (isAssetSigna ? PUBLIC_RESERVED_SIGNA_FOR_TX_FEE : 0)
+                )}
                 avatarIpfsHash={avatarIpfsHash || null}
               />
 
               {!!tokenBalance.length && (
-                <View className="border rounded-lg border-card-border dark:border-card-border-dark px-2 py-4 opacity-80 flex flex-col items-center gap-1">
+                <View className="border rounded-lg border-card-border dark:border-card-border-dark px-2 py-4 opacity-80 flex flex-col items-center gap-1 max-w-28">
                   <MaterialIcons
                     name="currency-exchange"
                     size={28}
                     color={iconColor.primary}
                   />
 
-                  <Text size="extraSmall" color="primary">
+                  <Text size="extraSmall" color="primary" className="text-center">
                     {t("transfer.changeAsset")}
                   </Text>
                 </View>
               )}
             </View>
+            <Text size="medium" color="muted">
+             {"("} {t("reservedBalance")}{" "}
+               {PUBLIC_RESERVED_SIGNA_FOR_TX_FEE}{" "}
+              <SignaSymbol /> {")"}
+            </Text>
           </Card>
         </Pressable>
 


### PR DESCRIPTION
Changes:
- Added a Clear Button for all text inputs (works on both iOS and Android)
- Security/Dependencies: Integrated react-native-expo-crypto-adapter from the Signum repository.
- Display recipient account name when available (resolved via Ledger service)
- Show reserved Signa balance (for transaction fees)