### PR TITLE
chore: remove web support and default to Expo Dev Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,50 +6,129 @@ Built with **Expo**, **React Native**, and **Expo Dev Client**, targeting both *
 
 ---
 
-## 📦 Requirements
+## 🛠️ Development
 
-- **Node**: see `.nvmrc`  
-- **JDK 17**  
-- **Android Gradle Plugin**: 8.1.1  
-- **Gradle**: 8.3  
-- **Xcode**: only required for *local* iOS builds — not needed when using **EAS Build**
+The setup supports development on **Windows, macOS, and Linux**, with parallel testing on **iOS and Android** devices.
+
+Windows 11 is fully supported. 
+macOS additionally allows local iOS simulator builds.
+
+**Expo Go App is not supported**, because of **native modules** dependencies (Quick Crypto library and Nitro modules). All local development and testing is done using the **Expo Dev Client**.
+
+More details: [https://docs.expo.dev/develop/development-builds/introduction/](https://docs.expo.dev/develop/development-builds/introduction/)
 
 ---
 
-## 🚀 Development
+This project supports **two local development workflows**, depending on your environment and use case.
 
-### Install dependencies
+
+### 📋 General Requirements
+
+- **Node.js** (see `.nvmrc`)
+- **npm**
+- **Expo CLI**
+- **EAS CLI**
+
+---
+
+**Prerequisite:** Dependencies must be installed once before using any development workflow:
+
 ```bash
 npm install
 ```
 
-### Start development client
+---
+
+### Option A: Expo Dev Client (recommended)
+
+#### 1. Build the development client
+
+Create an internal development build using EAS:
+
+```bash
+npm run build-dev
+```
+
+Install the generated build on your iOS and/or Android device.
+
+> **Important (iOS):** The iPhone must be registered in **Expo / Apple Developer provisioning**:
+>
+> - The device UDID needs to be added to the Apple Developer account
+> - The device must appear in Expo / EAS as an allowed device for development builds
+> - Otherwise the dev client cannot be installed or launched on iOS
+
+#### 2. Start the development server
+
+Start the Metro bundler in Dev Client mode:
+
+```bash
+npm start
+```
+
+If you run into caching or bundling issues, use:
+
+```bash
+npm run start-clean
+```
+
+#### 3. Open the app
+
+Open the app using the **Expo Dev Client** on your device. The app will connect to the running development server.
+
+> **Note (Device setup):**
+>
+> - **iOS:** Make sure *Developer Mode* is enabled
+>   - Settings → Privacy & Security → Developer Mode → ON
+>   - Device restart required
+> - **Android:** Enable *Developer options* and *USB debugging*
+>   - Settings → About phone → tap *Build number* 7×
+>   - Settings → Developer options → USB debugging
+
+---
+
+### Option B: Local native run (emulator / simulator)
+
+This workflow is useful for quick local testing using emulators or simulators.
+
+### 📋 Additional requirements (local native builds only)
+
+- **JDK 17**
+- **Android Gradle Plugin**: 8.1.1
+- **Gradle**: 8.3
+- **Android Studio**
+- **Xcode** (macOS only, required for local iOS builds)
+
+
+#### Start local native build
+
 ```bash
 npm run android
 # or
 npm run ios
 ```
 
-### Start without build cache
+> Note: `npm run ios` requires macOS.
+
+#### Start without build cache (optional)
+
 ```bash
 npx expo run:android --no-build-cache
 npx expo run:ios --no-build-cache
 ```
 
-### After installing new native libraries
+#### After installing new native libraries
+
 ```bash
 npm run prebuild
 ```
 
-
-### Sqlite Migrations
+#### SQLite migrations
 
 Change the schema in `src/db/schema.ts` and run:
 
 ```bash
 npx drizzle-kit migrate
 ```
-
 
 ---
 
@@ -123,38 +202,19 @@ https://docs.infinite.red/reactotron/
 
 ---
 
-## 🌐 Supported Platforms
-- **Android**  
-- **iOS**
-
----
-
 ## 🏗️ Build Profiles (EAS)
 
-The project uses **EAS Build** with the following profiles:
+This project uses multiple EAS build profiles with different guarantees depending on the target environment.
 
-| Profile | Purpose | Notes |
-|---------|---------|-------|
-| **development** | Dev Client builds | Debugging, Reactotron, Drizzle Studio |
-| **preview** | Internal test builds (APK / ad-hoc iOS) | QA & testing |
-| **production** | Store releases | Google Play & App Store |
-
-### Commands
-```bash
-# Development build
-eas build -p android --profile development
-
-# Preview build (APK)
-eas build -p android --profile preview
-
-# Production build
-eas build -p android --profile production
-eas build -p ios --profile production
-```
+| Profile     | Script                  | Description                                            |
+| ----------- | ----------------------- | ------------------------------------------------------ |
+| Development | `npm run build-dev`     | Internal dev client build, uncommitted changes allowed |
+| Preview     | `npm run build-preview` | Preview build, clean git state required                |
+| Production  | `npm run build-prod`    | Production build, clean git state required             |
 
 ---
 
-# 🔢 Versioning & App Updates
+## 🔢 Versioning & App Updates
 
 Correct versioning is essential for publishing builds to **Google Play** and **App Store Connect**.
 
@@ -286,4 +346,4 @@ See [Demo dApp README](./demo-dapp/README.md) for detailed instructions.
 ## 📝 License
 
 Apache License 2.0  
-© 2025 Signum Network
+© 2026 Signum Network

--- a/app.json
+++ b/app.json
@@ -41,9 +41,6 @@
       ],
       "versionCode": 1
     },
-    "web": {
-      "favicon": "./assets/favicon.png"
-    },
     "plugins": [
       "expo-router",
       "expo-secure-store",

--- a/eas.json
+++ b/eas.json
@@ -7,6 +7,7 @@
     "development": {
       "node": "20.18.0",
       "developmentClient": true,
+      "distribution": "internal",
       "env": {
         "EAS_BUILD_ENV": "development"
       }

--- a/package.json
+++ b/package.json
@@ -3,19 +3,26 @@
   "version": "2.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "start": "expo start",
-    "start-clean": "expo start -c",
+    "start": "expo start --dev-client",
+    "start-clean": "expo start -c --dev-client",
+
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web",
+
     "prebuild": "npx expo prebuild --clean",
     "expo-fix": "npx expo install --fix",
     "expo-doctor": "npx expo-doctor@latest",
+
     "ts-check": "tsc",
     "db-generate": "npx drizzle-kit generate",
     "prepare": "husky",
+
     "test-deeplink": "node scripts/test-deeplink.js",
-    "test-connect": "node scripts/test-connect-deeplink.js"
+    "test-connect": "node scripts/test-connect-deeplink.js",
+
+    "build-dev": "set EAS_NO_VCS=1 && eas build --profile development",
+    "build-preview": "eas build --profile preview",
+    "build-prod": "eas build --profile production"
   },
   "dependencies": {
     "@expo-google-fonts/space-mono": "^0.4.2",
@@ -45,6 +52,7 @@
     "expo-clipboard": "~8.0.7",
     "expo-constants": "~18.0.10",
     "expo-crypto": "~15.0.7",
+    "expo-dev-client": "~6.0.20",
     "expo-drizzle-studio-plugin": "^0.1.2",
     "expo-font": "^14.0.9",
     "expo-image": "~3.0.9",
@@ -76,7 +84,6 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
-    "react-native-web": "^0.21.0",
     "react-native-webview": "13.15.0",
     "react-native-worklets": "0.5.1",
     "react-number-format": "^5.4.3",


### PR DESCRIPTION
# 📦 Summary

This PR updates the EAS build workflow and local development setup to use the Expo Dev Client, as Expo Go can no longer be used due to native dependencies.

In addition, web support has been removed to simplify the project configuration and avoid unsupported platform builds.

---

# ✨ Changes

- Added consistent npm scripts for EAS builds:
  - `build-dev` for development builds (dirty git state allowed)
  - `build-preview` for preview builds (clean git state required)
  - `build-prod` for production builds (clean git state required)
- Updated the development build profile to use `distribution: internal`
- Updated local start scripts to make the Expo Dev Client the default for development
- Removed web platform support and related dependencies (`react-native-web`, web config)

---

# 🎯 Motivation

The app now uses native modules (Quick Crypto library and Nitro modules), which are not supported by Expo Go or the web platform.

To continue development and testing with native dependencies:

- Expo Dev Client builds are required
- EAS is used to generate installable dev clients for both iOS and Android
- Internal distribution allows parallel testing on multiple devices
- Removing web support avoids unsupported runtime errors and bundler conflicts (e.g. `import.meta` issues)

This setup enables ongoing development from Windows, macOS, or Linux without relying on Expo Go.

Difference between Expo Go and development builds:
https://docs.expo.dev/develop/development-builds/introduction/

---

# 🧪 How to test

Build and install the internal development client:

```bash
npm run build-dev
```

Start the local development server:

```bash
npm start
# or
npm run start-clean
```

Open the app using the Expo Dev Client on iOS or Android.

---

# 📝 Notes

- Expo Go is no longer supported for this project due to native dependencies
- Web platform support has been removed
- Development builds intentionally allow uncommitted changes
- Preview and production builds remain strict and reproducible
- No changes to application runtime behavior or production logic

