### PR TITLE
fix: prevent navigation crash by delaying route replacement

### DIFF
--- a/src/features/AccountWizard/Create/index.tsx
+++ b/src/features/AccountWizard/Create/index.tsx
@@ -105,9 +105,10 @@ export const CreateScreen = () => {
         });
       }
       setTimeout(() => {
-        setShowDialog(false);
-        router.replace("/dashboard/account");
-      }, 4000);
+        requestAnimationFrame(() => {
+          router.replace("/dashboard/account");
+        });
+      }, 2000);
     } catch (error) {
       console.error(error);
     }

--- a/src/features/AccountWizard/Import/index.tsx
+++ b/src/features/AccountWizard/Import/index.tsx
@@ -103,7 +103,10 @@ export const ImportScreen = () => {
 
             setActiveAccount(publicKey);
 
-            router.replace("/dashboard/overview");
+            //Delay navigation to next frame to avoid Fabric mount/unmount race
+            requestAnimationFrame(() => {
+              router.replace("/dashboard/overview");
+            });
           }
         );
         break;
@@ -142,7 +145,10 @@ export const ImportScreen = () => {
 
           setActiveAccount(watchAccountPublicKey);
 
-          router.replace("/dashboard/overview");
+          //Delay navigation to next frame to avoid Fabric mount/unmount race
+          requestAnimationFrame(() => {
+            router.replace("/dashboard/overview");
+          });
         } catch (error: any) {
           return alert(t("accountDoesNotExists"));
         }
@@ -249,8 +255,8 @@ export const ImportScreen = () => {
 
             <WalletNameField />
           </AccountWizardContainer>
-          </ScrollView>
-          <FormNavigation onSubmit={handleSubmit(onSubmit)} />
+        </ScrollView>
+        <FormNavigation onSubmit={handleSubmit(onSubmit)} />
       </KeyboardAnimatedContainer>
     </FormProvider>
   );


### PR DESCRIPTION
## 📦 Summary

This PR prevents a navigation crash caused by a React Native Fabric mount/unmount race condition when navigating immediately after state updates.

## ✨ Changes

- Delay navigation using `requestAnimationFrame`
- Ensure navigation happens in the next render frame
- Prevent potential Fabric mount/unmount race condition

### Before

Navigation could occasionally crash when `router.replace()` was executed immediately after state updates.

### After

Navigation is delayed to the next frame:

```ts
// Delay navigation to next frame to avoid Fabric mount/unmount race
requestAnimationFrame(() => {
  router.replace("/dashboard/overview");
});