### PR TITLE
feat(theme): add Rogue Ember dark theme with red-orange accents

### DIFF
--- a/src/features/Dashboard/Settings/Design/index.tsx
+++ b/src/features/Dashboard/Settings/Design/index.tsx
@@ -12,6 +12,7 @@ const AVAILABLE_DESIGNS: ThemeDesign[] = [
   "midnight",
   "solarized",
   "sunrise",
+  "rogueEmberDark"
 ];
 
 export const DesignSettingsScreen = () => {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -258,6 +258,10 @@
       "bubblegum": {
         "title": "Bubblegum",
         "description": "Verspieltes Pastell-Theme mit Rosa und Violett."
+      },
+      "rogueEmberDark": {
+        "title": "Rogue Ember",
+        "description": "Dunkles Tech-Theme mit Rot-Orange-Akzenten."
       }
     },
     "about": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -258,6 +258,10 @@
       "bubblegum": {
         "title": "Bubblegum",
         "description": "Playful pastel theme with pink and purple."
+      },
+      "rogueEmberDark": {
+        "title": "Rogue Ember",
+        "description": "Dark tech theme with red-orange accents."
       }
     },
     "about": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -258,6 +258,10 @@
       "bubblegum": {
         "title": "Bubblegum",
         "description": "Tema pastel y divertido con rosa y púrpura."
+      },
+      "rogueEmberDark": {
+        "title": "Rogue Ember",
+        "description": "Tema tecnológico oscuro con acentos rojo-naranja."
       }
     },
     "about": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -258,6 +258,10 @@
       "bubblegum": {
         "title": "Bubblegum",
         "description": "Thème pastel ludique avec rose et violet."
+      },
+      "rogueEmberDark": {
+        "title": "Rogue Ember",
+        "description": "Thème technologique sombre avec accents rouge-orange."
       }
     },
     "about": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -258,6 +258,10 @@
       "bubblegum": {
         "title": "Bubblegum",
         "description": "Tema pastel divertido com rosa e roxo."
+      },
+      "rogueEmberDark": {
+        "title": "Rogue Ember",
+        "description": "Tema tecnológico escuro com acentos vermelho-laranja."
       }
     },
     "about": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -258,6 +258,10 @@
       "bubblegum": {
         "title": "Bubblegum",
         "description": "Игрившая пастельная тема с розовым и фиолетовым."
+      },
+      "rogueEmberDark": {
+        "title": "Rogue Ember",
+        "description": "Тёмная техно-тема с красно-оранжевыми акцентами."
       }
     },
     "about": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -258,6 +258,10 @@
       "bubblegum": {
         "title": "泡泡糖",
         "description": "俏皮的粉色与紫色粉彩主题。"
+      },
+      "rogueEmberDark": {
+        "title": "Rogue Ember",
+        "description": "深色科技主题，带红橙色点缀。"
       }
     },
     "about": {

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -4,7 +4,8 @@ export type ThemeDesign =
   | "midnight"
   | "solarized"
   | "sunrise"
-  | "bubblegum";
+  | "bubblegum"
+  | "rogueEmberDark";
 
 export type ThemeTokens = {
   background: string;
@@ -99,4 +100,16 @@ export const themeTokens: TokenMap = {
     success: "#4FB3FF",
     error: "#C04AFF",
   },
+  rogueEmberDark: {
+    background: "#000000",
+    surface: "#05000A",
+    surfaceElevated: "#1a0101",
+    border: "#5C120C",
+    text: "#E5E7EB",
+    textMuted: "#8A817C",
+    primary: "#A62014",
+    primarySoft: "#A6201422",
+    success: "#F22F1D",
+    error: "#F28B05",
+  }
 };


### PR DESCRIPTION
## Summary

Adds a new dark theme **Rogue Ember**.

Since the wallet uses design tokens, creating new themes is very easy.  
This PR simply introduces a new color palette with black, graphite, and red-orange accents.

## Changes

- Added `rogueEmberDark` theme tokens
- Added theme metadata (title + description translations)
- Registered the theme in the theme selector

## Notes

Just experimenting a bit with the token system – turns out adding new designs is pretty straightforward. 😀

<img width="461" height="1024" alt="image" src="https://github.com/user-attachments/assets/6cd04971-6519-4338-ba86-b9444087463d" />
