### PR TITLE
refactor: remove magic keyboard offsets and centralize layout heights

### DIFF
--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -5,6 +5,7 @@ import {useSafeAreaInsets} from "react-native-safe-area-context";
 import {useAppTheme} from "@/hooks/useAppTheme";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import {StackActions} from "@react-navigation/native";
+import { TAB_BAR_BASE_HEIGHT } from "@/theme/constants";
 
 type TabBarIconProperties = { color: string };
 
@@ -23,7 +24,7 @@ export function AppNavigation() {
             screenOptions={{
                 headerShown: false,
                 tabBarStyle: {
-                    height: 72 + insets.bottom,
+                    height: TAB_BAR_BASE_HEIGHT + insets.bottom,
                     paddingBottom: 8 + insets.bottom,
                     paddingTop: 8,
                     backgroundColor: tokens.surfaceElevated ?? tokens.surface,

--- a/src/components/Form/NavButton.tsx
+++ b/src/components/Form/NavButton.tsx
@@ -3,8 +3,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button, type ButtonProps as ButtonProps } from "../Button";
 import { useAppTheme } from "@/hooks/useAppTheme";
 import { useAccountStore } from "@/hooks/useAccountStore";
+import { FORM_NAV_BUTTON_HEIGHT } from "@/theme/constants";
 
-const DEFAULT_HEIGHT = 78;
 
 interface Props extends ButtonProps {
   hidden?: boolean;
@@ -24,7 +24,7 @@ export const FormNavButton = ({ hidden, ...props }: Props) => {
   return (
     <View
       style={{
-        height: DEFAULT_HEIGHT + safeBottom,
+        height: FORM_NAV_BUTTON_HEIGHT + safeBottom,
         paddingBottom: safeBottom,
         backgroundColor: tokens.background,
         borderTopWidth: 1,

--- a/src/components/KeyboardAnimatedContainer.tsx
+++ b/src/components/KeyboardAnimatedContainer.tsx
@@ -5,26 +5,47 @@ import { useKeyboardPadding } from "@/hooks/useKeyboardPadding";
 
 type Props = PropsWithChildren<
   ViewProps & {
-    /** Fixed bottom space (e.g., sticky button / tab bar height) */
-    baseBottom?: number;
-    /** If false, first render snaps to target without animation */
+    /** Set true on screens without bottom tab bar, e.g. onboarding account-wizard */
+    noTabBar?: boolean;
+    /** Set true on screens without bottom form navigation button */
+    noFormNavButton?: boolean;
+    /** Optional small manual correction */
+    extraOffset?: number;
+    /** If false, first render snaps without animation */
     animateOnMount?: boolean;
+    /** Animation duration when keyboard opens */
+    openDuration?: number;
+    /** Animation duration when keyboard closes */
+    closeDuration?: number;
+    /** Ignore tiny ghost keyboard heights */
+    threshold?: number;
   }
 >;
 
 export function KeyboardAnimatedContainer({
   children,
   style,
-  baseBottom = 0,
+  noTabBar = false,
+  noFormNavButton = false,
+  extraOffset = 0,
   animateOnMount = true,
+  openDuration = 250,
+  closeDuration = 200,
+  threshold = 10,
   ...rest
 }: Props) {
-  const pad = useKeyboardPadding({ baseBottom, animateOnMount });
+  const animatedPaddingStyle = useKeyboardPadding({
+    noTabBar,
+    noFormNavButton,
+    extraOffset,
+    animateOnMount,
+    openDuration,
+    closeDuration,
+    threshold,
+  });
+
   return (
-    <Animated.View
-      style={[{ flex: 1 }, pad, style]}
-      {...rest}
-    >
+    <Animated.View style={[{ flex: 1 }, animatedPaddingStyle, style]} {...rest}>
       {children}
     </Animated.View>
   );

--- a/src/features/AccountWizard/Create/index.tsx
+++ b/src/features/AccountWizard/Create/index.tsx
@@ -27,7 +27,6 @@ import { useNodeHostStore } from "@/hooks/useNodeHostStore";
 import { Address } from "@signumjs/core";
 import { PUBLIC_SIGNUM_AVERAGE_BLOCK_TIME_IN_MINUTES } from "@/types/constants";
 import { useAppTheme } from "@/hooks/useAppTheme";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 
 
@@ -45,7 +44,6 @@ export const CreateScreen = () => {
   const { currentNetwork } = useNodeHostStore();
   const { iconColor } = useAppTheme();
   const [showDialog, setShowDialog] = useState(false);
-  const insets = useSafeAreaInsets();
 
   const methods = useForm<AccountCreation>({
     mode: "onChange",
@@ -117,7 +115,7 @@ export const CreateScreen = () => {
   return (
     <FormProvider {...methods}>
       <FormStepper />
-      <KeyboardAnimatedContainer baseBottom={isAccountEnrolled ? -150 : insets.bottom}>
+      <KeyboardAnimatedContainer noTabBar={!isAccountEnrolled}>
         <Dialog variant="full" visible={showDialog}>
           <View className="flex flex-col items-center justify-center gap-4 w-full">
             <Ionicons name="checkmark-circle" size={85} color={iconColor.green} />

--- a/src/features/AccountWizard/Import/index.tsx
+++ b/src/features/AccountWizard/Import/index.tsx
@@ -1,38 +1,38 @@
-import {useEffect} from "react";
-import {ScrollView, View} from "react-native";
-import {useTranslation} from "react-i18next";
-import {router} from "expo-router";
-import {useForm, FormProvider, type SubmitHandler} from "react-hook-form";
-import {yupResolver} from "@hookform/resolvers/yup";
-import type {BarcodeScanningResult} from "expo-camera";
-import {accountImportSchema} from "./utils/schemas";
-import type {AccountImport} from "./utils/types";
-import {AccountWizardContainer} from "../components/AccountWizardContainer";
-import {useAppTheme} from "@/hooks/useAppTheme";
-import {useAccountStore} from "@/hooks/useAccountStore";
-import {Text} from "@/components/Text";
-import {Button} from "@/components/Button";
-import {AccountType} from "@/types/account";
-import {HorizontalDivider} from "@/components/HorizontalDivider";
-import {CameraDialog} from "@/components/CameraDialog";
-import {getAccountPublicKey} from "@/utils/account/getAccountPublicKey";
-import {getLedgerService} from "@/utils/getLedgerService";
-import {Address} from "@signumjs/core";
-import {FormNavigation} from "./components/FormNavigation";
-import {WalletNameField} from "./sections/WalletNameField";
-import {SeedPhraseField} from "./sections/SeedPhraseField";
-import {AccountIdField} from "./sections/AccountIdField";
+import { useEffect } from "react";
+import { ScrollView, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { router } from "expo-router";
+import { useForm, FormProvider, type SubmitHandler } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import type { BarcodeScanningResult } from "expo-camera";
+import { accountImportSchema } from "./utils/schemas";
+import type { AccountImport } from "./utils/types";
+import { AccountWizardContainer } from "../components/AccountWizardContainer";
+import { useAppTheme } from "@/hooks/useAppTheme";
+import { useAccountStore } from "@/hooks/useAccountStore";
+import { Text } from "@/components/Text";
+import { Button } from "@/components/Button";
+import { AccountType } from "@/types/account";
+import { HorizontalDivider } from "@/components/HorizontalDivider";
+import { CameraDialog } from "@/components/CameraDialog";
+import { getAccountPublicKey } from "@/utils/account/getAccountPublicKey";
+import { getLedgerService } from "@/utils/getLedgerService";
+import { Address } from "@signumjs/core";
+import { FormNavigation } from "./components/FormNavigation";
+import { WalletNameField } from "./sections/WalletNameField";
+import { SeedPhraseField } from "./sections/SeedPhraseField";
+import { AccountIdField } from "./sections/AccountIdField";
 import {
     generateSecretKeys,
     saveSecretKey,
 } from "@/utils/sec/handleSecretKeys";
 import Ionicons from "@expo/vector-icons/Ionicons";
-import {KeyboardAnimatedContainer} from "@/components/KeyboardAnimatedContainer";
-import {AppHeader} from "@/components/AppHeader";
+import { KeyboardAnimatedContainer } from "@/components/KeyboardAnimatedContainer";
+import { AppHeader } from "@/components/AppHeader";
 
 export const ImportScreen = () => {
-    const {t} = useTranslation();
-    const {iconColor, tokens} = useAppTheme();
+    const { t } = useTranslation();
+    const { iconColor, tokens } = useAppTheme();
     const {
         accountWalletNames,
         accountPublicKeys,
@@ -53,7 +53,7 @@ export const ImportScreen = () => {
         },
     });
 
-    const {watch, setValue, resetField, handleSubmit} = methods;
+    const { watch, setValue, resetField, handleSubmit } = methods;
 
     const type = watch("type");
     const isAccountTypeMnemonic = type === AccountType.mnemonic;
@@ -73,7 +73,7 @@ export const ImportScreen = () => {
     };
 
     const onSubmit: SubmitHandler<AccountImport> = async (data) => {
-        const {walletName, account} = data;
+        const { walletName, account } = data;
 
         if (accountWalletNames.includes(walletName.toLowerCase())) {
             return alert(t("accountWizard.walletNameAlreadyUsed"));
@@ -81,7 +81,7 @@ export const ImportScreen = () => {
 
         switch (data.type) {
             case AccountType.mnemonic:
-                const {publicKey, signPrivateKey, agreementPrivateKey} =
+                const { publicKey, signPrivateKey, agreementPrivateKey } =
                     generateSecretKeys(account);
 
                 if (accountPublicKeys.includes(publicKey)) {
@@ -118,7 +118,7 @@ export const ImportScreen = () => {
                         resolvedAccountId = Address.create(account).getNumericId();
                     } catch {
                         // Not a valid address — try alias resolution
-                        const {ledgerService} = getLedgerService();
+                        const { ledgerService } = getLedgerService();
                         resolvedAccountId = await ledgerService.alias.resolveAliasToAccountId(account);
                     }
 
@@ -169,7 +169,7 @@ export const ImportScreen = () => {
                 title={t("accountWizard.quickStart.importCta")}
                 onBack={goBackwards}
             />
-            <KeyboardAnimatedContainer baseBottom={isAccountEnrolled ? -75 : 0}>
+            <KeyboardAnimatedContainer noTabBar={!isAccountEnrolled}>
                 <ScrollView
                     keyboardDismissMode="on-drag"
                     keyboardShouldPersistTaps="handled"
@@ -203,7 +203,7 @@ export const ImportScreen = () => {
                                     extraClassNames="flex-1 px-4"
                                     size="medium"
                                     titleClassName="font-medium"
-                                    pressableProps={{onPress: setMnemonicMode}}
+                                    pressableProps={{ onPress: setMnemonicMode }}
                                 />
 
                                 <Button
@@ -219,7 +219,7 @@ export const ImportScreen = () => {
                                     extraClassNames="flex-1 px-4"
                                     size="medium"
                                     titleClassName="font-medium"
-                                    pressableProps={{onPress: setWatchOnlyMode}}
+                                    pressableProps={{ onPress: setWatchOnlyMode }}
                                 />
                             </View>
                             {type === AccountType.mnemonic && (
@@ -231,7 +231,7 @@ export const ImportScreen = () => {
                                         expected="seed"
                                         onCodeScanned={onCodeScanned}
                                     />
-                                    <SeedPhraseField/>
+                                    <SeedPhraseField />
                                 </View>
                             )}
                             {type === AccountType.watchOnly && (
@@ -243,18 +243,18 @@ export const ImportScreen = () => {
                                         expected="address"
                                         onCodeScanned={onCodeScanned}
                                     />
-                                    <AccountIdField/>
+                                    <AccountIdField />
                                 </View>
                             )}
                         </View>
 
-                        <HorizontalDivider/>
+                        <HorizontalDivider />
 
-                        <WalletNameField/>
+                        <WalletNameField />
                     </AccountWizardContainer>
                 </ScrollView>
-                <FormNavigation onSubmit={handleSubmit(onSubmit)}/>
             </KeyboardAnimatedContainer>
+            <FormNavigation onSubmit={handleSubmit(onSubmit)} />
         </FormProvider>
     );
 };

--- a/src/features/Dashboard/ProfileEdit/index.tsx
+++ b/src/features/Dashboard/ProfileEdit/index.tsx
@@ -112,7 +112,7 @@ export const ProfileEditScreen = ({ accountId }: Props) => {
         <FormProvider {...methods}>
             <View className="flex-1">
                 {activeStep > Steps.DraftDialog && <FormStepper />}
-                <KeyboardAnimatedContainer baseBottom={-150}>
+                <KeyboardAnimatedContainer>
                     <ScrollView
                         ref={scrollRef}
                         keyboardDismissMode="on-drag"

--- a/src/hooks/useKeyboardPadding.ts
+++ b/src/hooks/useKeyboardPadding.ts
@@ -9,29 +9,43 @@ import {
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
+import {
+  TAB_BAR_BASE_HEIGHT,
+  FORM_NAV_BUTTON_HEIGHT,
+} from "@/theme/constants";
 
 type Options = {
-  /** Fixed bottom spacing, e.g. for a sticky button/tab bar */
-  baseBottom?: number;
+  /** Set true on screens without bottom tab bar, e.g. onboarding account-wizard */
+  noTabBar?: boolean;
+  /** Set true on screens without bottom form navigation button */
+  noFormNavButton?: boolean;
+  /** Optional small manual correction */
+  extraOffset?: number;
   /** If false, first render snaps without animation */
   animateOnMount?: boolean;
-  /** Animation duration when keyboard opens (ms) */
+  /** Animation duration when keyboard opens */
   openDuration?: number;
-  /** Animation duration when keyboard closes (ms) */
+  /** Animation duration when keyboard closes */
   closeDuration?: number;
-  /** Ignore very small "ghost" heights (e.g. stale values) */
+  /** Ignore tiny ghost keyboard heights */
   threshold?: number;
 };
 
 /**
- * Hook that returns an animated style with a bottom padding
- * that increases when the keyboard is visible.
+ * Returns an animated style with bottom padding that grows when the keyboard opens.
  *
- * Combines reanimated’s useAnimatedKeyboard with real RN Keyboard events
- * and also uses keyboardDidHide to hard-reset padding.
+ * Calculation:
+ * keyboard shift = keyboard height - already occupied bottom space
+ *
+ * Bottom space assumptions:
+ * - Tab bar exists by default and already includes safe area bottom inset
+ * - FormNavButton exists by default
+ * - On screens without tab bar, safe area bottom is used instead
  */
 export function useKeyboardPadding({
-  baseBottom = 0,
+  noTabBar = false,
+  noFormNavButton = false,
+  extraOffset = 0,
   animateOnMount = true,
   openDuration = 250,
   closeDuration = 200,
@@ -39,58 +53,57 @@ export function useKeyboardPadding({
 }: Options = {}) {
   const insets = useSafeAreaInsets();
   const isFocused = useIsFocused();
-  const kbd = useAnimatedKeyboard();
+  const keyboard = useAnimatedKeyboard();
 
-  // Track real visibility from RN events (0 = hidden, 1 = visible)
   const visible = useSharedValue(0);
-
-  // Shared value that holds the current paddingBottom
-  const padding = useSharedValue(baseBottom);
-
-  // Flag to avoid animation on the very first paint
+  const padding = useSharedValue(0);
   const mounted = useSharedValue(animateOnMount ? 1 : 0);
 
   useEffect(() => {
-    const onShow = () => (visible.value = 1);
-    const onWillHide = () => (visible.value = 0);
-    const onDidHide = () => {
-      // Hard reset padding on full hide
-      padding.value = baseBottom;
-    };
+    const onShow = () => { visible.value = 1; };
+    const onHide = () => { visible.value = 0; padding.value = 0; };
 
-    const show =
+    const showSub =
       Platform.OS === "ios"
         ? Keyboard.addListener("keyboardWillShow", onShow)
         : Keyboard.addListener("keyboardDidShow", onShow);
 
-    const willHide =
+    const hideSub =
       Platform.OS === "ios"
-        ? Keyboard.addListener("keyboardWillHide", onWillHide)
-        : Keyboard.addListener("keyboardDidHide", onWillHide);
+        ? Keyboard.addListener("keyboardWillHide", onHide)
+        : Keyboard.addListener("keyboardDidHide", onHide);
 
-    const didHide = Keyboard.addListener("keyboardDidHide", onDidHide);
+    const didHideSub = Keyboard.addListener("keyboardDidHide", onHide);
 
     return () => {
-      show.remove();
-      willHide.remove();
-      didHide.remove();
+      showSub.remove();
+      hideSub.remove();
+      didHideSub.remove();
       visible.value = 0;
-      padding.value = baseBottom;
+      padding.value = 0;
     };
-  }, [baseBottom, visible, padding]);
+  }, [padding, visible]);
 
   useEffect(() => {
     mounted.value = 1;
   }, [mounted]);
 
   const style = useAnimatedStyle(() => {
-    const raw = kbd.height.value ?? 0;
-    const safeBottom = insets.bottom;
-    const height = Math.max(0, raw - safeBottom);
+    const keyboardHeight = keyboard.height.value ?? 0;
 
-    const active = isFocused && visible.value === 1 && height > threshold;
-    const target = baseBottom + (active ? height : 0);
-    const duration = active ? openDuration : closeDuration;
+    const tabBarHeight = noTabBar ? insets.bottom : TAB_BAR_BASE_HEIGHT + insets.bottom;
+    const formNavHeight = noFormNavButton ? 0 : FORM_NAV_BUTTON_HEIGHT;
+
+    const occupiedBottomSpace = tabBarHeight + formNavHeight;
+
+    const isKeyboardVisible =
+      isFocused && visible.value === 1 && keyboardHeight > threshold;
+
+    const target = isKeyboardVisible
+      ? Math.max(0, keyboardHeight - occupiedBottomSpace + extraOffset)
+      : 0;
+
+    const duration = isKeyboardVisible ? openDuration : closeDuration;
 
     if (!mounted.value) {
       padding.value = target;
@@ -104,11 +117,13 @@ export function useKeyboardPadding({
 
     return { paddingBottom: padding.value };
   }, [
-    baseBottom,
+    closeDuration,
+    extraOffset,
     insets.bottom,
     isFocused,
+    noFormNavButton,
+    noTabBar,
     openDuration,
-    closeDuration,
     threshold,
   ]);
 

--- a/src/theme/constants.ts
+++ b/src/theme/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Layout constants used across the app.
+ * Keep these values in sync with components like TabBar, FormNavButton and useKeyboardPadding.
+ */
+
+export const TAB_BAR_BASE_HEIGHT = 72;
+
+export const FORM_NAV_BUTTON_HEIGHT = 78;


### PR DESCRIPTION
## Summary

Refactors keyboard layout handling and removes several magic offsets used to align inputs with the keyboard.

## Changes

- Improved `useKeyboardPadding` calculation
- Added support for screens without a tab bar (`noTabBar`)
- Added support for screens without a form navigation button (`noFormNavButton`)
- Centralized bottom layout heights in `theme/constants.ts`
  - `TAB_BAR_BASE_HEIGHT`
  - `FORM_NAV_BUTTON_HEIGHT`

## Result

- Keyboard aligns correctly with input fields
- No more manual negative offsets
- Bottom layout heights defined in a single place