### PR TITLE
feat: add custom passphrase mode, BIP39 suggestions, and invalid word highlighting (fix #166)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@signumjs/util": "^2.0.6",
         "@tanstack/react-query": "^5.80.7",
         "babel-plugin-inline-import": "^3.0.0",
+        "bip39": "^3.1.0",
         "clsx": "^2.1.1",
         "colord": "^2.9.3",
         "date-fns": "^4.1.0",
@@ -3788,6 +3789,18 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5765,6 +5778,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
       }
     },
     "node_modules/boolbase": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@signumjs/util": "^2.0.6",
     "@tanstack/react-query": "^5.80.7",
     "babel-plugin-inline-import": "^3.0.0",
+    "bip39": "^3.1.0",
     "clsx": "^2.1.1",
     "colord": "^2.9.3",
     "date-fns": "^4.1.0",

--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -1,0 +1,55 @@
+import { Pressable, View } from "react-native";
+import { Text } from "@/components/Text";
+import { useAppTheme } from "@/hooks/useAppTheme";
+
+interface Props {
+  value: boolean;
+  onPress: () => void;
+  label?: string;
+  disabled?: boolean;
+}
+
+export const ToggleSwitch = ({ value, onPress, label, disabled }: Props) => {
+  const { tokens } = useAppTheme();
+
+  return (
+    <Pressable
+      accessibilityRole="switch"
+      accessibilityState={{ checked: value, disabled }}
+      onPress={onPress}
+      disabled={disabled}
+      className="flex-row items-center gap-3"
+      style={{ opacity: disabled ? 0.6 : 1 }}
+    >
+      <View
+        style={{
+          width: 35,
+          height: 20,
+          borderRadius: 10,
+          borderColor: value ? tokens.textMuted : tokens.textMuted,
+          borderWidth: 1,
+          padding: 2,
+          backgroundColor: value ? tokens.surface : tokens.surface,
+          justifyContent: "center",
+        }}
+      >
+        <View
+          style={{
+            width: 16,
+            height: 16,
+            borderRadius: 8,
+            backgroundColor: value ? tokens.primary : tokens.text,
+            alignSelf: value ? "flex-end" : "flex-start",
+            elevation: 3,
+          }}
+        />
+      </View>
+
+      {!!label && (
+        <Text size="small" className="font-medium">
+          {label}
+        </Text>
+      )}
+    </Pressable>
+  );
+};

--- a/src/features/AccountWizard/Import/components/PassphraseTextInput.tsx
+++ b/src/features/AccountWizard/Import/components/PassphraseTextInput.tsx
@@ -1,0 +1,194 @@
+import { useMemo } from "react";
+import {
+  View,
+  Pressable,
+  TextInput as NativeTextInput,
+  Text as RNText,
+  type TextInputProps,
+  Platform,
+} from "react-native";
+import { useAppTheme } from "@/hooks/useAppTheme";
+
+interface Props extends Omit<TextInputProps, "value" | "onChangeText"> {
+  value: string;
+  onChangeText: (text: string) => void;
+  wordlist: Set<string>;
+  validateWords?: boolean;
+  showSuggestions?: boolean;
+  maxSuggestions?: number;
+}
+
+const splitKeepingSpaces = (text: string) => text.split(/(\s+)/);
+
+const getCurrentWord = (text: string) => {
+  const match = text.match(/(?:^|\s)(\S*)$/);
+  return match?.[1] ?? "";
+};
+
+const replaceCurrentWord = (text: string, suggestion: string) => {
+  return text.replace(/(?:^|\s)(\S*)$/, (match) => {
+    const startsWithSpace = /^\s/.test(match);
+    return `${startsWithSpace ? " " : ""}${suggestion} `;
+  });
+};
+
+export const PassphraseTextInput = ({
+  value,
+  onChangeText,
+  wordlist,
+  validateWords = true,
+  showSuggestions = false,
+  maxSuggestions = 5,
+  ...props
+}: Props) => {
+  const { tokens } = useAppTheme();
+
+  const parts = useMemo(() => splitKeepingSpaces(value || ""), [value]);
+
+  const currentWord = useMemo(() => getCurrentWord(value || ""), [value]);
+
+  const suggestions = useMemo(() => {
+    if (!showSuggestions || !validateWords) return [];
+    if (currentWord.length < 2) return [];
+
+    return Array.from(wordlist)
+      .filter((word) => word.startsWith(currentWord.toLowerCase()))
+      .slice(0, maxSuggestions);
+  }, [currentWord, showSuggestions, validateWords, wordlist, maxSuggestions]);
+
+  return (
+    <View className="w-full">
+      <View
+        style={{
+          minHeight: 130,
+          borderWidth: 1,
+          borderColor: tokens.border,
+          borderRadius: 8,
+          backgroundColor: tokens.surfaceElevated,
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        <View
+          pointerEvents="none"
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            zIndex: 1,
+            paddingHorizontal: 16,
+            paddingVertical: 14,
+          }}
+        >
+          <RNText
+            style={{
+              fontSize: 18,
+              lineHeight: 24,
+              color: tokens.text,
+            }}
+          >
+            {parts.map((part, index) => {
+              const isSpace = /^\s+$/.test(part);
+
+              const nextPart = parts[index + 1] || "";
+              const isCompletedWord = isSpace || /^\s+$/.test(nextPart);
+
+              const isInvalid =
+                validateWords &&
+                !isSpace &&
+                part.length > 0 &&
+                isCompletedWord &&
+                !wordlist.has(part);
+
+              return (
+                <RNText
+                  key={`${part}-${index}`}
+                  style={{
+                    fontSize: 18,
+                    lineHeight: 24,
+                    color: isInvalid ? tokens.error : tokens.text,
+                    textDecorationLine: isInvalid ? "underline" : "none",
+                    textDecorationColor: isInvalid ? tokens.error : undefined,
+                  }}
+                >
+                  {part}
+                </RNText>
+              );
+            })}
+          </RNText>
+        </View>
+
+        <NativeTextInput
+          {...props}
+          value={value}
+          onChangeText={onChangeText}
+          multiline
+          textAlignVertical="top"
+          autoCorrect={false}
+          autoComplete="off"
+          autoCapitalize="none"
+          spellCheck={false}
+          importantForAutofill="no"
+          textContentType="none"
+          keyboardType="visible-password"
+          placeholderTextColor={tokens.textMuted}
+          underlineColorAndroid="transparent"
+          allowFontScaling={false}
+          style={{
+            minHeight: 130,
+            paddingHorizontal: 16,
+            paddingVertical: 14,
+            fontSize: 18,
+            lineHeight: 24,
+            color:
+              Platform.OS === "android"
+                ? "rgba(0,0,0,0.01)"
+                : "rgba(0,0,0,0.001)",
+            backgroundColor: "transparent",
+            borderRadius: 8,
+            zIndex: 2,
+            borderWidth: 0,
+            includeFontPadding: false,
+          }}
+          selectionColor={tokens.primary}
+        />
+      </View>
+
+      <View
+        style={{
+          paddingTop: 8,
+          minHeight: 38,
+          justifyContent: "center",
+        }}
+      >
+        {suggestions.length > 0 &&
+          !(suggestions.length === 1 && suggestions[0] === currentWord.toLowerCase()) && (
+          <View className="flex-row flex-wrap gap-2">
+            {suggestions.map((suggestion) => (
+              <Pressable
+                key={suggestion}
+                onPress={() =>
+                  onChangeText(replaceCurrentWord(value, suggestion))
+                }
+                style={{
+                  paddingHorizontal: 10,
+                  paddingVertical: 4,
+                  borderRadius: 999,
+                  borderWidth: 1,
+                  borderColor: tokens.primary,
+                  backgroundColor: tokens.primary,
+                }}
+              >
+                <RNText style={{ color: tokens.text, fontSize: 14 }}>
+                  {suggestion}
+                </RNText>
+              </Pressable>
+            ))}
+          </View>
+        )}
+      </View>
+    </View>
+  );
+};

--- a/src/features/AccountWizard/Import/index.tsx
+++ b/src/features/AccountWizard/Import/index.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { ScrollView, View } from "react-native";
+import { useEffect, useRef } from "react";
+import { Animated, Easing, ScrollView, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { router } from "expo-router";
 import { useForm, FormProvider, type SubmitHandler } from "react-hook-form";
@@ -171,6 +171,36 @@ export const ImportScreen = () => {
         }
     };
 
+    // Ensures BIP39 word suggestions below the input is visible
+    const scrollRef = useRef<ScrollView>(null);
+    const scrollY = useRef(0);
+    const seedPhraseY = useRef(0);
+    const scrollAnimation = useRef(new Animated.Value(0)).current;
+    const smoothScrollTo = (targetY: number) => {
+    scrollAnimation.stopAnimation();
+    scrollAnimation.setValue(scrollY.current);
+    const listenerId = scrollAnimation.addListener(({ value }) => {
+        scrollRef.current?.scrollTo({
+        y: value,
+        animated: false,
+        });
+    });
+      // Animate scroll
+    Animated.timing(scrollAnimation, {
+        toValue: targetY,
+        duration: 1000,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: false,
+    }).start(() => {
+        scrollAnimation.removeListener(listenerId);
+    });
+    };
+    const scrollToSeedPhrase = () => {
+    setTimeout(() => {
+        smoothScrollTo(Math.max(0, seedPhraseY.current + 190)); // 190 offset to position the seed phrase suggestions above the keyboard.
+    }, 200); // small delay to allow keyboard + layout to settle
+    };
+
     return (
         <FormProvider {...methods}>
             <AppHeader
@@ -179,8 +209,13 @@ export const ImportScreen = () => {
             />
             <KeyboardAnimatedContainer noTabBar={!isAccountEnrolled}>
                 <ScrollView
-                    keyboardDismissMode="on-drag"
-                    keyboardShouldPersistTaps="handled"
+                ref={scrollRef}
+                keyboardDismissMode="on-drag"
+                keyboardShouldPersistTaps="handled"
+                scrollEventThrottle={16}
+                onScroll={(event) => {
+                    scrollY.current = event.nativeEvent.contentOffset.y;
+                }}
                 >
                     <AccountWizardContainer>
                         <View className="flex flex-col items-center justify-center w-full gap-4">
@@ -239,7 +274,13 @@ export const ImportScreen = () => {
                                         expected="seed"
                                         onCodeScanned={onCodeScanned}
                                     />
-                                    <SeedPhraseField />
+                                    <View
+                                        onLayout={(event) => {
+                                        seedPhraseY.current = event.nativeEvent.layout.y;
+                                        }}
+                                    >
+                                        <SeedPhraseField onFocus={scrollToSeedPhrase} />
+                                    </View>
                                 </View>
                             )}
                             {type === AccountType.watchOnly && (

--- a/src/features/AccountWizard/Import/sections/SeedPhraseField/index.tsx
+++ b/src/features/AccountWizard/Import/sections/SeedPhraseField/index.tsx
@@ -1,20 +1,36 @@
+import { useState } from "react";
 import { View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useFormContext, Controller } from "react-hook-form";
 import { Text } from "@/components/Text";
 import { Card } from "@/components/Card";
-import { TextInput } from "@/components/TextInput";
 import { FormCheckbox } from "@/components/Form/Checkbox";
 import type { AccountImport } from "../../utils/types";
 import { ResolvedAccountCard } from "../../components/ResolvedAccountCard";
+import { ToggleSwitch } from "@/components/ToggleSwitch";
+import * as bip39 from "bip39";
+import { PassphraseTextInput } from "../../components/PassphraseTextInput";
 
-export const SeedPhraseField = () => {
+type Props = {
+  onFocus?: () => void;
+  onBlur?: () => void;
+};
+
+export const SeedPhraseField = ({ onFocus }: Props) => {
   const { t } = useTranslation();
   const { control, watch, setValue } = useFormContext<AccountImport>();
 
   const mnemonicAccountAgreement = watch("mnemonicAccountAgreement");
+  const [allowCustomPassphrase, setAllowCustomPassphrase] = useState(false);
+  
   const toggleAgreement = () =>
     setValue("mnemonicAccountAgreement", !mnemonicAccountAgreement);
+
+  const toggleAllowCustomPassphrase = () =>
+    setAllowCustomPassphrase((value) => !value);
+
+  const wordlist = bip39.wordlists.english;
+  const wordlistSet = new Set(wordlist);
 
   return (
     <View className="gap-4 w-full">
@@ -28,18 +44,40 @@ export const SeedPhraseField = () => {
         <Controller
           control={control}
           render={({ field: { onChange, onBlur, value } }) => (
-            <TextInput
+            <PassphraseTextInput
               onBlur={onBlur}
-              onChangeText={(text) => onChange(text.toLowerCase())} 
+              onFocus={onFocus}
+              onChangeText={(text) => {
+                if (allowCustomPassphrase) {
+                  onChange(text);
+                } else {
+                  // remove special chars, keep only letters and spaces
+                  const sanitized = text.toLowerCase().replace(/[^a-z\s]/g, ""); // only a-z + space
+
+                  onChange(sanitized);
+                }
+              }}
               value={value}
-              extraClassNames="font-medium w-full min-h-40"
-              size="large"
-              multiline
-              textAlignVertical="top"
+              wordlist={wordlistSet}
+              validateWords={!allowCustomPassphrase}
+              showSuggestions={!allowCustomPassphrase}
+              maxSuggestions={4}
             />
           )}
           name="account"
         />
+        <View className="flex flex-row items-center justify-between">
+          <ToggleSwitch
+            value={allowCustomPassphrase}
+            onPress={toggleAllowCustomPassphrase}
+            label={t(
+              "accountWizard.importAccount.importAccountUseCustomPassphrase",
+            )}
+          />
+        </View>
+        <Text size="small" color="muted">
+          {t("accountWizard.importAccount.importAccountCustomPassphraseHint")}
+        </Text>
       </Card>
 
       <ResolvedAccountCard />

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -172,7 +172,9 @@
       "importAccountAlreadyExists": "Dieses Konto existiert bereits in deiner Wallet, bitte gehe zu den Kontoeinstellungen und verwende es!",
       "importAccountResolvedAddress": "Kontoadresse: {{address}}",
       "importAccountResolvedName": "Kontoname: {{name}}",
-      "importAccountResolvedAddressHint": "Bitte überprüfe die Adresse, um sicherzustellen, dass du das richtige Konto importierst."
+      "importAccountResolvedAddressHint": "Bitte überprüfe die Adresse, um sicherzustellen, dass du das richtige Konto importierst.",
+      "importAccountUseCustomPassphrase": "Benutzerdefinierte Passphrase",
+      "importAccountCustomPassphraseHint": "Aktiviere diese Option, um individuelle Passphrasen einzugeben. Groß- und Kleinschreibung sowie Sonderzeichen werden beibehalten."
     },
     "walletNameAlreadyUsed": "Der Wallet‑Name wird bereits verwendet, bitte wähle einen anderen!",
     "maxAccountsReached": "Maximale Anzahl an Konten ({{max}}) erreicht. Bitte entferne eine bestehende Wallet, um fortzufahren."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -172,7 +172,9 @@
       "importAccountAlreadyExists": "This account already exists on your wallet, please go to account settings and use it!",
       "importAccountResolvedAddress": "Account address: {{address}}",
       "importAccountResolvedName": "Account Name: {{name}}",
-      "importAccountResolvedAddressHint": "Please verify the address to make sure you are importing the correct account."
+      "importAccountResolvedAddressHint": "Please verify the address to make sure you are importing the correct account.",
+      "importAccountUseCustomPassphrase": "Custom passphrase",
+      "importAccountCustomPassphraseHint": "Enable this option to enter custom passphrases. Uppercase/lowercase letters and special characters will be kept as entered."
     },
     "walletNameAlreadyUsed": "The wallet name is already being used, please choose another one!",
     "maxAccountsReached": "Maximum number of accounts ({{max}}) reached. Please remove an existing wallet to continue."

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -172,7 +172,9 @@
       "importAccountAlreadyExists": "Esta cuenta ya existe en tu wallet; ve a los ajustes de la cuenta y úsala",
       "importAccountResolvedAddress": "Dirección de la cuenta: {{address}}",
       "importAccountResolvedName": "Nombre de la cuenta: {{name}}",
-      "importAccountResolvedAddressHint": "Verifica la dirección para asegurarte de que estás importando la cuenta correcta."
+      "importAccountResolvedAddressHint": "Verifica la dirección para asegurarte de que estás importando la cuenta correcta.",
+      "importAccountUseCustomPassphrase": "Personalizada passphrase",
+      "importAccountCustomPassphraseHint": "Activa esta opción para introducir passphrase personalizadas. Se conservarán las mayúsculas/minúsculas y los caracteres especiales."
     },
     "walletNameAlreadyUsed": "Ese nombre de wallet ya está en uso; ¡elige otro!",
     "maxAccountsReached": "Se alcanzó el número máximo de cuentas ({{max}}). Por favor, elimina una wallet existente para continuar."

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -172,7 +172,9 @@
       "importAccountAlreadyExists": "Ce compte existe déjà dans votre portefeuille, veuillez aller dans les paramètres du compte et l'utiliser !",
       "importAccountResolvedAddress": "Adresse du compte : {{address}}",
       "importAccountResolvedName": "Nom du compte : {{name}}",
-      "importAccountResolvedAddressHint": "Veuillez vérifier l'adresse pour vous assurer d'importer le bon compte."
+      "importAccountResolvedAddressHint": "Veuillez vérifier l'adresse pour vous assurer d'importer le bon compte.",
+      "importAccountUseCustomPassphrase": "Passphrase personnalisée",
+      "importAccountCustomPassphraseHint": "Activez cette option pour saisir des passphrase personnalisées. Les majuscules/minuscules et les caractères spéciaux seront conservés."
     },
     "walletNameAlreadyUsed": "Ce nom de portefeuille est déjà utilisé, veuillez en choisir un autre !",
     "maxAccountsReached": "Nombre maximum de comptes ({{max}}) atteint. Veuillez supprimer un portefeuille existant pour continuer."

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -172,7 +172,9 @@
       "importAccountAlreadyExists": "Esta conta já existe na sua carteira; vá para as configurações da conta e use-a",
       "importAccountResolvedAddress": "Endereço da conta: {{address}}",
       "importAccountResolvedName": "Nome da conta: {{name}}",
-      "importAccountResolvedAddressHint": "Verifique o endereço para ter certeza de que está importando a conta correta."
+      "importAccountResolvedAddressHint": "Verifique o endereço para ter certeza de que está importando a conta correta.",
+      "importAccountUseCustomPassphrase": "Passphrase personalizada",
+      "importAccountCustomPassphraseHint": "Ative esta opção para inserir passphrase personalizadas. Letras maiúsculas/minúsculas e caracteres especiais serão preservados."
     },
     "walletNameAlreadyUsed": "Esse nome de carteira já está em uso; escolha outro!",
     "maxAccountsReached": "Número máximo de contas ({{max}}) atingido. Por favor, remova uma carteira existente para continuar."

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -172,7 +172,9 @@
       "importAccountAlreadyExists": "Этот аккаунт уже существует в вашем кошельке; перейдите в настройки аккаунта и используйте его",
       "importAccountResolvedAddress": "Адрес аккаунта: {{address}}",
       "importAccountResolvedName": "Имя аккаунта: {{name}}",
-      "importAccountResolvedAddressHint": "Проверьте адрес, чтобы убедиться, что вы импортируете правильный аккаунт."
+      "importAccountResolvedAddressHint": "Проверьте адрес, чтобы убедиться, что вы импортируете правильный аккаунт.",
+      "importAccountUseCustomPassphrase": "Пользовательская фраза-пароль",
+      "importAccountCustomPassphraseHint": "Включите эту опцию, чтобы вводить пользовательские фразы-пароли. Регистр символов и специальные символы будут сохранены."
     },
     "walletNameAlreadyUsed": "Имя кошелька уже используется; выберите другое!",
     "maxAccountsReached": "Достигнуто максимальное количество аккаунтов ({{max}}). Пожалуйста, удалите существующий кошелёк, чтобы продолжить."

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -172,7 +172,9 @@
       "importAccountAlreadyExists": "Цей акаунт вже існує у вашому гаманці; перейдіть у налаштування акаунту та використовуйте його",
       "importAccountResolvedAddress": "Адреса акаунту: {{address}}",
       "importAccountResolvedName": "Ім'я акаунту: {{name}}",
-      "importAccountResolvedAddressHint": "Перевірте адресу, щоб переконатися, що ви імпортуєте правильний акаунт."
+      "importAccountResolvedAddressHint": "Перевірте адресу, щоб переконатися, що ви імпортуєте правильний акаунт.",
+      "importAccountUseCustomPassphrase": "Власна парольна фраза",
+      "importAccountCustomPassphraseHint": "Увімкніть цю опцію, щоб вводити власні парольні фрази. Регістр символів і спеціальні символи будуть збережені."
     },
     "walletNameAlreadyUsed": "Ім'я гаманця вже використовується; оберіть інше!",
     "maxAccountsReached": "Досягнуто максимальну кількість акаунтів ({{max}}). Будь ласка, видаліть існуючий гаманець, щоб продовжити."

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -172,7 +172,9 @@
       "importAccountAlreadyExists": "该账户已存在于你的钱包中，请前往账户设置使用它！",
       "importAccountResolvedAddress": "账户地址：{{address}}",
       "importAccountResolvedName": "账户名称：{{name}}",
-      "importAccountResolvedAddressHint": "请核实地址，确保你导入的是正确的账户。"
+      "importAccountResolvedAddressHint": "请核实地址，确保你导入的是正确的账户。",
+      "importAccountUseCustomPassphrase": "自定义密码短语",
+      "importAccountCustomPassphraseHint": "启用此选项以输入自定义密码短语。大小写字母和特殊字符将被保留。"
     },
     "walletNameAlreadyUsed": "钱包名称已被使用，请选择其他名称！",
     "maxAccountsReached": "已达到最大账户数量 ({{max}})。请删除一个现有钱包后再继续。"


### PR DESCRIPTION
**This PR enhances the seed phrase input experience during account import and resolves issue #166 by introducing a flexible input mode for both standard BIP39 and custom passphrases.**



A new toggle allows switching between two modes:

**Default (BIP39 mode):**

- Input is normalized to lowercase
- Words are validated against the BIP39 wordlist (2048 words)
- Invalid words are highlighted
- Autocomplete suggestions are shown

**Custom passphrase mode:**

- Input is preserved exactly as typed
- Uppercase characters allowed
- Arbitrary UTF-8 characters allowed
- Wordlist validation disabled
- Suggestions disabled

--

Native input features (autocorrect, autocomplete) explicitly disabled

https://github.com/user-attachments/assets/a086d4c0-33fc-47e9-96a1-4cfd895c9930


