### PR TITLE
fix: add cancel button to camera dialog (#169)

### DIFF
--- a/src/components/CameraDialog.tsx
+++ b/src/components/CameraDialog.tsx
@@ -155,6 +155,13 @@ export const CameraDialog = ({onCodeScanned, expected}: Props) => {
                                 type="primary"
                                 pressableProps={{onPress: request}}
                             />
+                            <Button
+                                icon={<FontAwesome6 name="window-close" size={24} color="white"/>}
+                                fullWidth
+                                title={t("cancel")}
+                                type="error"
+                                pressableProps={{onPress: hideDialog}}
+                            />
                         </Fragment>
                     )}
                 </View>


### PR DESCRIPTION
Fixes a UX issue on iOS where users could get stuck inside camera dialog after denying camera permissions.

<img width="739" height="1600" alt="image" src="https://github.com/user-attachments/assets/fbe7af00-9767-496b-bc24-c691781a5a6a" />
